### PR TITLE
Fix crash in protected area in drive when user violates area protection and allow "protection_bypass" to bypass ME security.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -5,6 +5,7 @@ read_globals = {
 	"dump",
 	"ItemStack",
 	"pipeworks",
+	"unified_inventory",
 	"PseudoRandom",
 	"stairsplus",
 	"intllib",

--- a/modules/crafting/materials.lua
+++ b/modules/crafting/materials.lua
@@ -4,8 +4,6 @@
 local me = microexpansion
 local substitute_basic_materials = microexpansion.settings.simple_craft == true or not minetest.get_modpath("basic_materials")
 
-local gold_wire_recipe = nil
-
 if minetest.get_modpath("mcl_core") then
 	gold_wire_recipe = {
 		{ 2, {

--- a/modules/crafting/shared.lua
+++ b/modules/crafting/shared.lua
@@ -4,9 +4,6 @@ local me = microexpansion
 
 -- custom items that are used by multiple devices
 
-local steel_infused_obsidian_ingot_recipe = nil
-local machine_casing_recipe = nil
-
 if minetest.get_modpath("mcl_core") then
 	steel_infused_obsidian_ingot_recipe = {
 		{ 2, {

--- a/modules/network/network.lua
+++ b/modules/network/network.lua
@@ -79,14 +79,17 @@ end
 
 function network:get_access_level(player)
 	local name
+	local has_bypass = minetest.check_player_privs(player, "protection_bypass")
 	if not player then
 		return self.default_access_level
+	elseif has_bypass then
+		return me.constants.access_levels.full
 	elseif type(player) == "string" then
 		name = player
 	else
 		name = player:get_player_name()
 	end
-	if not self.access then
+	if not self.access or not  then
 		return self.default_access_level
 	end
 	return self.access[name] or self.default_access_level

--- a/modules/network/network.lua
+++ b/modules/network/network.lua
@@ -89,7 +89,7 @@ function network:get_access_level(player)
 	else
 		name = player:get_player_name()
 	end
-	if not self.access or not  then
+	if not self.access and not has_bypass then
 		return self.default_access_level
 	end
 	return self.access[name] or self.default_access_level

--- a/modules/network/network.lua
+++ b/modules/network/network.lua
@@ -83,7 +83,7 @@ function network:get_access_level(player)
 	if not player then
 		return self.default_access_level
 	elseif has_bypass then
-		return me.constants.access_levels.full
+		return me.constants.security.access_levels.full
 	elseif type(player) == "string" then
 		name = player
 	else

--- a/modules/storage/drive.lua
+++ b/modules/storage/drive.lua
@@ -349,13 +349,14 @@ microexpansion.register_node("drive", {
    me.send_event(pos,"disconnect")
   end,
 	allow_metadata_inventory_put = function(pos, _, _, stack, player)
+    local name = player:get_player_name()
 		local network = me.get_connected_network(pos)
 		if network then
 			if network:get_access_level(player) < access_level.interact then
 				return 0
 			end
-		elseif minetest.is_protected(pos, player) then
-			minetest.record_protection_violation(pos, player)
+		elseif minetest.is_protected(pos, name) then
+			minetest.record_protection_violation(pos, name)
 			return 0
 		end
 		if minetest.get_item_group(stack:get_name(), "microexpansion_cell") == 0 then
@@ -384,14 +385,15 @@ microexpansion.register_node("drive", {
 		me.send_event(pos,"items",{net=network})
 	end,
 	allow_metadata_inventory_take = function(pos,_,_,stack, player) --args: pos, listname, index, stack, player
+    local name = player:get_player_name()
 		local network = me.get_connected_network(pos)
 		if network then
 			write_drive_cells(pos,network)
 			if network:get_access_level(player) < access_level.interact then
 				return 0
 			end
-		elseif minetest.is_protected(pos, player) then
-			minetest.record_protection_violation(pos, player)
+		elseif minetest.is_protected(pos, name) then
+			minetest.record_protection_violation(pos, name)
 			return 0
 		end
 		return stack:get_count()


### PR DESCRIPTION
You put the player object in minetest.is_protected and minetest.record_protection_violation instead of the correct, player name.

Also this PR let players with "protection_bypass" bypass ME security and have full access.